### PR TITLE
Initialize i2c_dev to nullptr in constructor

### DIFF
--- a/Adafruit_MLX90632.cpp
+++ b/Adafruit_MLX90632.cpp
@@ -25,6 +25,7 @@
 Adafruit_MLX90632::Adafruit_MLX90632() {
   TO0 = 25.0; // Initialize previous object temperature
   TA0 = 25.0; // Initialize previous ambient temperature
+  i2c_dev = nullptr;
 }
 
 /*!


### PR DESCRIPTION
This alleviates the issue on initialisation and particularly on destruction and reinitialization of the driver.


Here's an example sketch to prove the issue:
```cpp
// Basic test sketch for Adafruit MLX90632 Far Infrared Temperature Sensor
// Modified to use dynamic allocation with reinitializaiton on each loop

#include "Adafruit_MLX90632.h"
#include <Wire.h>

// Configuration options
#define USE_CUSTOM_I2C false  // Set to false to use default I2C
#define CUSTOM_SDA_PIN 21    // Custom SDA pin (ESP32 example)
#define CUSTOM_SCL_PIN 22    // Custom SCL pin (ESP32 example)

Adafruit_MLX90632* mlx = nullptr;
TwoWire* i2c_instance = nullptr;

void setup() {
  Serial.begin(115200);
  while (!Serial) delay(10);
  
  Serial.println(F("Adafruit MLX90632 Dynamic Allocation Test"));
  Serial.println(F("Driver will be reinitialized on each loop cycle"));
  
  // Optionally initialize I2C in setup
  if (USE_CUSTOM_I2C) {
    Serial.println(F("Initializing custom I2C instance..."));
    i2c_instance = &Wire1;
    
    // Initialize I2C with custom pins (ESP32/ESP8266 example)
    #if defined(ESP32) || defined(ESP8266)
      i2c_instance->begin(CUSTOM_SDA_PIN, CUSTOM_SCL_PIN);
    #else
      i2c_instance->begin(); // Use default pins for other platforms
    #endif
    
    Serial.print(F("I2C initialized with SDA: "));
    Serial.print(CUSTOM_SDA_PIN);
    Serial.print(F(", SCL: "));
    Serial.println(CUSTOM_SCL_PIN);
  } else {
    Serial.println(F("Using default I2C initialization"));
    i2c_instance = &Wire; // Will use default I2C in begin()
    i2c_instance->begin();
  }
  
  Serial.println(F("Starting main loop...\n"));
}

void loop() {
  Serial.println("new instance creation...");
  // Create new instance of the driver
  mlx = new Adafruit_MLX90632();
  Serial.println("new instance created!");
  
  // Initialize the sensor
  bool initSuccess;
  Serial.println(F("Using default I2C for sensor initialization"));
  initSuccess = mlx->begin(MLX90632_DEFAULT_ADDR, i2c_instance);
  
  if (!initSuccess) {
    Serial.println(F("Failed to find MLX90632 chip - will retry next cycle"));
    delete mlx;
    mlx = nullptr;
    delay(1000); // Wait before retry
    return;
  }
  
  Serial.println(F("MLX90632 Found! Configuring..."));
  
  // Reset the device
  if (!mlx->reset()) {
    Serial.println(F("Device reset failed - will retry next cycle"));
    delete mlx;
    mlx = nullptr;
    delay(1000);
    return;
  }
  
  // Get device information
  uint64_t productID = mlx->getProductID();
  Serial.print(F("Product ID: 0x"));
  Serial.print((uint32_t)(productID >> 32), HEX);
  Serial.println((uint32_t)(productID & 0xFFFFFFFF), HEX);
  
  uint16_t productCode = mlx->getProductCode();
  Serial.print(F("Product Code: 0x"));
  Serial.println(productCode, HEX);
  
  uint16_t eepromVersion = mlx->getEEPROMVersion();
  Serial.print(F("EEPROM Version: 0x"));
  Serial.println(eepromVersion, HEX);
  
  // Decode product code bits
  uint8_t fov = (productCode >> 8) & 0x3;
  uint8_t package = (productCode >> 5) & 0x7; 
  uint8_t accuracy = productCode & 0x1F;
  
  Serial.print(F("FOV: "));
  Serial.println(fov == 0 ? F("50°") : F("Unknown"));
  
  Serial.print(F("Package: "));
  Serial.println(package == 1 ? F("SFN 3x3") : F("Unknown"));
  
  Serial.print(F("Accuracy: "));
  if (accuracy == 1) {
    Serial.println(F("Medical"));
  } else if (accuracy == 2) {
    Serial.println(F("Standard")); 
  } else {
    Serial.println(F("Unknown"));
  }
  
  // Configure sensor settings
  Serial.println(F("\n--- Configuring Sensor ---"));
  
  // Set mode to continuous
  if (!mlx->setMode(MLX90632_MODE_CONTINUOUS)) {
    Serial.println(F("Failed to set mode - will retry next cycle"));
    delete mlx;
    mlx = nullptr;
    delay(1000);
    return;
  }
  
  mlx90632_mode_t currentMode = mlx->getMode();
  Serial.print(F("Current mode: "));
  switch (currentMode) {
    case MLX90632_MODE_HALT:
      Serial.println(F("Halt"));
      break;
    case MLX90632_MODE_SLEEPING_STEP:
      Serial.println(F("Sleeping Step"));
      break;
    case MLX90632_MODE_STEP:
      Serial.println(F("Step"));
      break;
    case MLX90632_MODE_CONTINUOUS:
      Serial.println(F("Continuous"));
      break;
    default:
      Serial.println(F("Unknown"));
  }
  
  // Set measurement select (medical)
  if (!mlx->setMeasurementSelect(MLX90632_MEAS_MEDICAL)) {
    Serial.println(F("Failed to set measurement select to Medical - will retry next cycle"));
    delete mlx;
    mlx = nullptr;
    delay(1000);
    return;
  }
  
  mlx90632_meas_select_t currentMeasSelect = mlx->getMeasurementSelect();
  Serial.print(F("Current measurement select: "));
  switch (currentMeasSelect) {
    case MLX90632_MEAS_MEDICAL:
      Serial.println(F("Medical"));
      break;
    case MLX90632_MEAS_EXTENDED_RANGE:
      Serial.println(F("Extended Range"));
      break;
    default:
      Serial.println(F("Unknown"));
  }
  
  // Set refresh rate (2Hz)
  if (!mlx->setRefreshRate(MLX90632_REFRESH_2HZ)) {
    Serial.println(F("Failed to set refresh rate to 2Hz - will retry next cycle"));
    delete mlx;
    mlx = nullptr;
    delay(1000);
    return;
  }
  
  mlx90632_refresh_rate_t currentRefreshRate = mlx->getRefreshRate();
  Serial.print(F("Current refresh rate: "));
  switch (currentRefreshRate) {
    case MLX90632_REFRESH_0_5HZ:
      Serial.println(F("0.5 Hz"));
      break;
    case MLX90632_REFRESH_1HZ:
      Serial.println(F("1 Hz"));
      break;
    case MLX90632_REFRESH_2HZ:
      Serial.println(F("2 Hz"));
      break;
    case MLX90632_REFRESH_4HZ:
      Serial.println(F("4 Hz"));
      break;
    case MLX90632_REFRESH_8HZ:
      Serial.println(F("8 Hz"));
      break;
    case MLX90632_REFRESH_16HZ:
      Serial.println(F("16 Hz"));
      break;
    case MLX90632_REFRESH_32HZ:
      Serial.println(F("32 Hz"));
      break;
    case MLX90632_REFRESH_64HZ:
      Serial.println(F("64 Hz"));
      break;
    default:
      Serial.println(F("Unknown"));
  }
  
  // Clear new data flag before starting measurements
  if (!mlx->resetNewData()) {
    Serial.println(F("Failed to reset new data flag - will retry next cycle"));
    delete mlx;
    mlx = nullptr;
    delay(1000);
    return;
  }
  
  Serial.println(F("Configuration complete. Taking measurements..."));
  
  // Take several measurements before destroying the object
  for (int i = 0; i < 5; i++) {
    // Wait for new data (with timeout)
    unsigned long startTime = millis();
    while (!mlx->isNewData()) {
      if (millis() - startTime > 2000) { // 2 second timeout
        Serial.println(F("Timeout waiting for new data"));
        break;
      }
      delay(10);
    }
    
    if (mlx->isNewData()) {
      Serial.print(F("Measurement "));
      Serial.print(i + 1);
      Serial.print(F(" - Cycle Position: "));
      Serial.println(mlx->readCyclePosition());
      
      // Read ambient temperature
      double ambientTemp = mlx->getAmbientTemperature();
      Serial.print(F("  Ambient: "));
      Serial.print(ambientTemp, 4);
      Serial.println(F(" °C"));
      
      // Read object temperature
      double objectTemp = mlx->getObjectTemperature();
      Serial.print(F("  Object: "));
      if (isnan(objectTemp)) {
        Serial.println(F("NaN (invalid cycle position)"));
      } else {
        Serial.print(objectTemp, 4);
        Serial.println(F(" °C"));
      }
      
      // Reset new data flag after reading
      if (!mlx->resetNewData()) {
        Serial.println(F("Failed to reset new data flag"));
      }
      
      Serial.println();
    }
    
    delay(100); // Small delay between measurements
  }
  
  // Clean up - delete the driver instance and set pointer to nullptr
  Serial.println(F("Destroying driver instance..."));
  delete mlx;
  mlx = nullptr;
  
  Serial.println(F("Driver destroyed. Waiting before next cycle...\n"));
  Serial.println(F("========================================\n"));
  
  // Wait before next reinitialisation cycle
  delay(3000);
}
```