### PR TITLE
comment out MLX90632_DEBUG define

### DIFF
--- a/Adafruit_MLX90632.cpp
+++ b/Adafruit_MLX90632.cpp
@@ -17,7 +17,7 @@
 
 #include "Adafruit_MLX90632.h"
 
-#define MLX90632_DEBUG
+// #define MLX90632_DEBUG
 
 /*!
  *    @brief  Instantiates a new MLX90632 class

--- a/examples/test_MLX90632/test_MLX90632.ino
+++ b/examples/test_MLX90632/test_MLX90632.ino
@@ -143,7 +143,7 @@ void setup() {
   }
   
   // Clear new data flag before starting continuous measurements
-  Serial.println(F("\\n--- Starting Continuous Measurements ---"));
+  Serial.println(F("\n--- Starting Continuous Measurements ---"));
   if (!mlx.resetNewData()) {
     Serial.println(F("Failed to reset new data flag"));
     while (1) { delay(10); }


### PR DESCRIPTION
disables debug mode by default

also removing extra \ in new line print in example